### PR TITLE
Upgrade backup_migrate module to 7.x-3.5.

### DIFF
--- a/sites/all/modules/backup_migrate/backup_migrate.info
+++ b/sites/all/modules/backup_migrate/backup_migrate.info
@@ -34,9 +34,9 @@ files[] = includes/sources.filesource.inc
 files[] = tests/BackupMigrateHelper.test
 files[] = tests/BackupMigrateBasicsTest.test
 
-; Information added by Drupal.org packaging script on 2018-01-24
-version = "7.x-3.4"
+; Information added by Drupal.org packaging script on 2018-02-05
+version = "7.x-3.5"
 core = "7.x"
 project = "backup_migrate"
-datestamp = "1516810618"
+datestamp = "1517871486"
 

--- a/sites/all/modules/backup_migrate/backup_migrate.install
+++ b/sites/all/modules/backup_migrate/backup_migrate.install
@@ -769,3 +769,10 @@ function backup_migrate_update_7305() {
     'default' => 'builtin',
   ));
 }
+
+/**
+ * Leave a message to explain the mixup over the backup option.
+ */
+function backup_migrate_update_7306() {
+  drupal_set_message(t('Please note that release 7.x-3.4 had a bug which caused all backups to be overwritten instead of having a timestamp added. Please review all backup settings to ensure they work as intended.'), 'warning');
+}

--- a/sites/all/modules/backup_migrate/backup_migrate.module
+++ b/sites/all/modules/backup_migrate/backup_migrate.module
@@ -1446,8 +1446,8 @@ function backup_migrate_perform_backup(&$settings) {
   timer_start('backup_migrate_backup');
 
   // If not in 'safe mode', increase the maximum execution time:
-  if (!ini_get('safe_mode') && strpos(ini_get('disable_functions'), 'set_time_limit') === FALSE && ini_get('max_execution_time') < 1200) {
-    set_time_limit(variable_get('backup_migrate_backup_max_time', 1200));
+  if (!ini_get('safe_mode') && ini_get('max_execution_time') < variable_get('backup_migrate_backup_max_time', 1200)) {
+    drupal_set_time_limit(variable_get('backup_migrate_backup_max_time', 1200));
   }
 
   // Confirm the destinations are valid
@@ -1525,7 +1525,7 @@ function backup_migrate_perform_restore($destination_id, $file, $settings = arra
 
   // If not in 'safe mode', increase the maximum execution time:
   if (!ini_get('safe_mode') && ini_get('max_execution_time') < variable_get('backup_migrate_backup_max_time', 1200)) {
-    set_time_limit(variable_get('backup_migrate_restore_max_time', 1200));
+    drupal_set_time_limit(variable_get('backup_migrate_restore_max_time', 1200));
   }
 
   // Make the settings into a default profile.

--- a/sites/all/modules/backup_migrate/includes/destinations.file.inc
+++ b/sites/all/modules/backup_migrate/includes/destinations.file.inc
@@ -34,7 +34,7 @@ class backup_migrate_destination_files extends backup_migrate_destination {
       $filepath = rtrim($dir, "/") ."/". $file->filename();
 
       // Allow files to be overwritten by the filesystem.
-      $replace_method = $settings->append_timestamp == 1 ? FILE_EXISTS_REPLACE : FILE_EXISTS_RENAME;
+      $replace_method = $settings->append_timestamp == 2 ? FILE_EXISTS_REPLACE : FILE_EXISTS_RENAME;
 
       // Copy the file if there are multiple destinations.
       if (count($settings->get_destinations()) > 1) {

--- a/sites/all/modules/backup_migrate/includes/files.inc
+++ b/sites/all/modules/backup_migrate/includes/files.inc
@@ -154,7 +154,7 @@ function _backup_migrate_construct_filename($settings) {
 
   // Generate a timestamp if needed.
   $timestamp = '';
-  if ($settings->append_timestamp == 2 && $settings->timestamp_format) {
+  if ($settings->append_timestamp == 1 && $settings->timestamp_format) {
     $timestamp = format_date(time(), 'custom', $settings->timestamp_format);
   }
 

--- a/sites/all/modules/backup_migrate/includes/profiles.inc
+++ b/sites/all/modules/backup_migrate/includes/profiles.inc
@@ -123,17 +123,17 @@ function _backup_migrate_ui_backup_settings_form($profile) {
   $form['file']['append_timestamp'] = array(
     "#type" => "radios",
     '#options' => array(
-      0 => t('Create seperate backups even if `Backup file name` is the same.'),
-      1 => t('Overwrite backup.'),
-      2 => t('Append timestamp.'),
+      0 => t('Create separate backups if `Backup file name` already exists'),
+      2 => t('Overwrite the existing backup file'),
+      1 => t('Append the timestamp'),
     ),
-    "#title" => t("Save modes."),
+    "#title" => t("Save mode"),
     "#default_value" => $profile->append_timestamp,
   );
   $form['file']['timestamp_format_wrapper'] = array(
     '#type' => 'backup_migrate_dependent',
     '#dependencies' => array(
-      'append_timestamp' => 2,
+      'append_timestamp' => 1,
     ),
   );
   $form['file']['timestamp_format_wrapper']['timestamp_format'] = array(


### PR DESCRIPTION
**Release notes**
_This fixes a critical issue in 3.4 that caused backups to be overwritten instead of appended with a timestamp._ 

_Our sincerest apologies for that mistake. If your backup settings have been changed since updating to 3.4 please review them to ensure that they are appending the timestamp as intended._

https://www.drupal.org/project/backup_migrate/releases/7.x-3.5